### PR TITLE
Fix OPD protected time

### DIFF
--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -15,7 +15,6 @@ import {
   PlayIcon,
 } from 'lucide-react'
 import Link from 'next/link'
-import { ReactNode } from 'react'
 
 type OtherPhase = 'preparation-time' | 'poi'
 

--- a/app/speechTypes.tsx
+++ b/app/speechTypes.tsx
@@ -31,7 +31,7 @@ export const speechTypes = {
     shortName: 'Half (3.5 min)',
     timeLimits: {
       totalRegularTime: 3.5 * secondsPerMinute,
-      protectedStart: 0.5 * secondsPerMinute,
+      protectedStart: 1 * secondsPerMinute,
       protectedEnd: 0.5 * secondsPerMinute,
       gracePeriod: 15,
       poi: 15,


### PR DESCRIPTION
According to the [rules](https://www.streitkultur.net/wp-content/uploads/2025/07/Regelwerk-V15.pdf) (A.3.1 d)), the half-speeches have a regular 1m protected time at the start.